### PR TITLE
Enable assertions in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,4 +37,5 @@ checkstyle {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }


### PR DESCRIPTION
Realized that we didn't enable assertions in build.gradle from the progress check in the [tp dashboard](https://nus-cs2113-ay1920s2.github.io/website/admin/tp-progress-dashboard.html)