### PR TITLE
Update TimelineCommand with restricted period feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,4 +37,5 @@ checkstyle {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/seedu/tp/commands/TimelineCommand.java
+++ b/src/main/java/seedu/tp/commands/TimelineCommand.java
@@ -32,6 +32,14 @@ public class TimelineCommand extends Command {
         this.endDate = null;
     }
 
+    /**
+     * Constructor for TimelineCommand.
+     *
+     * @param flashcardList list containing all flashcards
+     * @param ui            instance for user interaction
+     * @param startDate     the date to start listing flashcards from (inclusive)
+     * @param endDate       the date after which to stop listing flashcards from
+     */
     public TimelineCommand(FlashcardList flashcardList, Ui ui, String startDate, String endDate) {
         assert flashcardList != null : "Invalid null FlashcardList!";
         assert ui != null : "Invalid null Ui!";

--- a/src/main/java/seedu/tp/commands/TimelineCommand.java
+++ b/src/main/java/seedu/tp/commands/TimelineCommand.java
@@ -1,7 +1,11 @@
 package seedu.tp.commands;
 
+import seedu.tp.exceptions.InvalidDateFormatException;
 import seedu.tp.flashcard.FlashcardList;
+import seedu.tp.parser.Parser;
 import seedu.tp.ui.Ui;
+
+import java.time.LocalDate;
 
 /**
  * Command to show a timeline for the existing flashcards.
@@ -9,6 +13,8 @@ import seedu.tp.ui.Ui;
 public class TimelineCommand extends Command {
     private FlashcardList flashcardList;
     private Ui ui;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
     /**
      * Constructor for TimelineCommand.
@@ -22,12 +28,30 @@ public class TimelineCommand extends Command {
 
         this.flashcardList = flashcardList;
         this.ui = ui;
+        this.startDate = null;
+        this.endDate = null;
+    }
+
+    public TimelineCommand(FlashcardList flashcardList, Ui ui, String startDate, String endDate) {
+        assert flashcardList != null : "Invalid null FlashcardList!";
+        assert ui != null : "Invalid null Ui!";
+        assert startDate != null : "Invalid null startDate!";
+        assert endDate != null : "Invalid null endDate!";
+
+        this.flashcardList = flashcardList;
+        this.ui = ui;
+        try {
+            this.startDate = Parser.parseDate(startDate);
+            this.endDate = Parser.parseDate(endDate);
+        } catch (InvalidDateFormatException e) {
+            System.out.println("That date format couldn't be parsed!");
+        }
     }
 
     @Override
     public void execute() {
         LOGGER.info("Listing the flashcards in order sorted by time...");
-        ui.listAllFlashcardsOrdered(flashcardList);
+        ui.listAllFlashcardsOrdered(flashcardList, startDate, endDate);
         LOGGER.info("Listed the flashcards in order sorted by time.");
     }
 }

--- a/src/main/java/seedu/tp/flashcard/EventFlashcard.java
+++ b/src/main/java/seedu/tp/flashcard/EventFlashcard.java
@@ -10,6 +10,7 @@ import static seedu.tp.utils.Constants.END_DATE_FIELD;
 import static seedu.tp.utils.Constants.NAME_FIELD;
 import static seedu.tp.utils.Constants.START_DATE_FIELD;
 import static seedu.tp.utils.Constants.SUMMARY_FIELD;
+import static seedu.tp.utils.Constants.DIVIDER;
 
 /**
  * Event flashcard.
@@ -64,6 +65,18 @@ public class EventFlashcard extends Flashcard {
      */
     public LocalDate getEndDate() {
         return endDate;
+    }
+
+    /**
+     * Gets a short description of the flashcard, without summary or details.
+     *
+     * @return String of shortDescription of the flashcard
+     */
+    @Override
+    public String getShortDescription() {
+        String shortDescription = this.name + DIVIDER + this.startDate + " to " + this.endDate
+                                    + DIVIDER + this.getReviewIcon() + DIVIDER + this.getPriorityAsString();
+        return shortDescription;
     }
 
     /**

--- a/src/main/java/seedu/tp/flashcard/Flashcard.java
+++ b/src/main/java/seedu/tp/flashcard/Flashcard.java
@@ -139,9 +139,7 @@ public abstract class Flashcard implements Comparable<Flashcard> {
      *
      * @return a shortened description of the flashcard
      */
-    public String getShortDescription() {
-        return EMPTY_STRING;
-    }
+    public abstract String getShortDescription();
 
     /**
      * Check if the current instance is equal to the object passed in.

--- a/src/main/java/seedu/tp/flashcard/Flashcard.java
+++ b/src/main/java/seedu/tp/flashcard/Flashcard.java
@@ -7,6 +7,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 
+import static seedu.tp.utils.Constants.EMPTY_STRING;
 import static seedu.tp.utils.Constants.LOG_FOLDER;
 
 /**
@@ -75,7 +76,7 @@ public abstract class Flashcard implements Comparable<Flashcard> {
      * @return "Y" for Yes if reviewed, else "N" for No.
      */
     public String getReviewIcon() {
-        return (isReviewed ? "Y" : "N");
+        return (isReviewed ? "/" : "X");
     }
 
 
@@ -132,6 +133,13 @@ public abstract class Flashcard implements Comparable<Flashcard> {
     public List<String> getDetails() {
         return details;
     }
+
+    /**
+     * To be implemented by child classes.
+     *
+     * @return a shortened description of the flashcard
+     */
+    public String getShortDescription() { return EMPTY_STRING; }
 
     /**
      * Check if the current instance is equal to the object passed in.

--- a/src/main/java/seedu/tp/flashcard/Flashcard.java
+++ b/src/main/java/seedu/tp/flashcard/Flashcard.java
@@ -139,7 +139,9 @@ public abstract class Flashcard implements Comparable<Flashcard> {
      *
      * @return a shortened description of the flashcard
      */
-    public String getShortDescription() { return EMPTY_STRING; }
+    public String getShortDescription() {
+        return EMPTY_STRING;
+    }
 
     /**
      * Check if the current instance is equal to the object passed in.

--- a/src/main/java/seedu/tp/flashcard/OtherFlashcard.java
+++ b/src/main/java/seedu/tp/flashcard/OtherFlashcard.java
@@ -4,6 +4,7 @@ import seedu.tp.ui.Ui;
 
 import java.util.List;
 
+import static seedu.tp.utils.Constants.DIVIDER;
 import static seedu.tp.utils.Constants.NAME_FIELD;
 import static seedu.tp.utils.Constants.SUMMARY_FIELD;
 
@@ -33,6 +34,18 @@ public class OtherFlashcard extends Flashcard {
         String summary = ui.promptUserForRequiredField(SUMMARY_FIELD);
         List<String> details = ui.promptUserForDetails();
         return new OtherFlashcard(name, summary, details);
+    }
+
+    /**
+     * Gets a short description of the flashcard, without summary or details.
+     *
+     * @return String of shortDescription of the flashcard
+     */
+    @Override
+    public String getShortDescription() {
+        String shortDescription = this.name + DIVIDER
+                + this.getReviewIcon() + DIVIDER + this.getPriorityAsString();
+        return shortDescription;
     }
 
     /**

--- a/src/main/java/seedu/tp/flashcard/PersonFlashcard.java
+++ b/src/main/java/seedu/tp/flashcard/PersonFlashcard.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import static seedu.tp.utils.Constants.BIRTH_DATE_FIELD;
 import static seedu.tp.utils.Constants.DEATH_DATE_FIELD;
+import static seedu.tp.utils.Constants.DIVIDER;
 import static seedu.tp.utils.Constants.NAME_FIELD;
 import static seedu.tp.utils.Constants.SUMMARY_FIELD;
 
@@ -82,6 +83,18 @@ public class PersonFlashcard extends Flashcard {
         stringBuilder.append("Details:").append(System.lineSeparator());
         stringBuilder.append(getDetailsString(details));
         return stringBuilder.toString();
+    }
+
+    /**
+     * Gets a short description of the flashcard, without summary or details.
+     *
+     * @return String of shortDescription of the flashcard
+     */
+    @Override
+    public String getShortDescription() {
+        String shortDescription = this.name + DIVIDER + this.birthDate + " to " + this.deathDate
+                + DIVIDER + this.getReviewIcon() + DIVIDER + this.getPriorityAsString();
+        return shortDescription;
     }
 
     /**

--- a/src/main/java/seedu/tp/parser/Parser.java
+++ b/src/main/java/seedu/tp/parser/Parser.java
@@ -250,7 +250,11 @@ public class Parser {
                 throw new InvalidInputFormatException();
             }
         case TIMELINE_COMMAND:
-            return new TimelineCommand(flashcardList, ui);
+            try {
+                return new TimelineCommand(flashcardList, ui, splitInput[1], splitInput[2]);
+            } catch (IndexOutOfBoundsException e) {
+                return new TimelineCommand(flashcardList, ui);
+            }
         case GROUP_COMMAND:
             return new GroupCommand(groupFactory, groupList);
         case ADD_FLASHCARD_TO_GROUP_COMMAND:

--- a/src/main/java/seedu/tp/ui/Ui.java
+++ b/src/main/java/seedu/tp/ui/Ui.java
@@ -379,7 +379,8 @@ public class Ui {
     }
 
     /**
-     * Prints out all flashcards in the list ordered by start/birth date. Other cards come last
+     * Prints out all flashcards in the list ordered by start/birth date. Other cards come last.
+     * Used for TimelineCommand.
      *
      * @param flashcardList the list of flashcards to be printed out
      */
@@ -393,9 +394,9 @@ public class Ui {
 
         List<Flashcard> flashcards = new ArrayList<>(flashcardList.getFlashcards());
         Collections.sort(flashcards);
-        System.out.println("Here's a sorted list of the flashcards you have:");
+        System.out.println("Flashcards sorted by date:");
         for (Flashcard f : flashcards) {
-            System.out.println(f);
+            System.out.println(BULLET_POINT + f.getShortDescription());
         }
     }
 

--- a/src/main/java/seedu/tp/ui/Ui.java
+++ b/src/main/java/seedu/tp/ui/Ui.java
@@ -404,30 +404,41 @@ public class Ui {
                 System.out.println(BULLET_POINT + f.getShortDescription());
             }
         } else {
-            System.out.println("Listing flashcards from " + startDate + " to " + endDate + "...");
-            boolean noFlashcards = true;
-            for (Flashcard f : flashcards) {
-                if (f instanceof EventFlashcard) {
-                    EventFlashcard eventFlashcard = (EventFlashcard) f;
-                    LocalDate eventStartDate = eventFlashcard.getStartDate();
-                    if (eventStartDate.compareTo(startDate) >= 0
+            listFlashcardsInPeriod(flashcards, startDate, endDate);
+        }
+    }
+
+    /**
+     * Lists flashcards from a specified time period only, in sorted order.
+     *
+     * @param sortedFlashcards the sorted list of all flashcards
+     * @param startDate        the date to start listing flashcards from (inclusive)
+     * @param endDate          the date after which to stop listing flashcards from
+     */
+    private void listFlashcardsInPeriod(List<Flashcard> sortedFlashcards, LocalDate startDate, LocalDate endDate) {
+        System.out.println("Listing flashcards from " + startDate + " to " + endDate + "...");
+        boolean noFlashcards = true;
+        for (Flashcard f : sortedFlashcards) {
+            if (f instanceof EventFlashcard) {
+                EventFlashcard eventFlashcard = (EventFlashcard) f;
+                LocalDate eventStartDate = eventFlashcard.getStartDate();
+                if (eventStartDate.compareTo(startDate) >= 0
                         && eventStartDate.compareTo(endDate) <= 0) {
-                        System.out.println(BULLET_POINT + f.getShortDescription());
-                        noFlashcards = false;
-                    }
-                } else if (f instanceof PersonFlashcard) {
-                    PersonFlashcard personFlashcard = (PersonFlashcard) f;
-                    LocalDate personBirthDate = personFlashcard.getBirthDate();
-                    if (personBirthDate.compareTo(startDate) >= 0
+                    System.out.println(BULLET_POINT + f.getShortDescription());
+                    noFlashcards = false;
+                }
+            } else if (f instanceof PersonFlashcard) {
+                PersonFlashcard personFlashcard = (PersonFlashcard) f;
+                LocalDate personBirthDate = personFlashcard.getBirthDate();
+                if (personBirthDate.compareTo(startDate) >= 0
                         && personBirthDate.compareTo(endDate) <= 0) {
-                        System.out.println(BULLET_POINT + f.getShortDescription());
-                        noFlashcards = false;
-                    }
+                    System.out.println(BULLET_POINT + f.getShortDescription());
+                    noFlashcards = false;
                 }
             }
-            if (noFlashcards) {
-                System.out.println("No flashcards found in this period.");
-            }
+        }
+        if (noFlashcards) {
+            System.out.println("No flashcards found in this period.");
         }
     }
 

--- a/src/main/java/seedu/tp/ui/Ui.java
+++ b/src/main/java/seedu/tp/ui/Ui.java
@@ -1,8 +1,10 @@
 package seedu.tp.ui;
 
 import seedu.tp.exceptions.InvalidDateFormatException;
+import seedu.tp.flashcard.EventFlashcard;
 import seedu.tp.flashcard.Flashcard;
 import seedu.tp.flashcard.FlashcardList;
+import seedu.tp.flashcard.PersonFlashcard;
 import seedu.tp.group.FlashcardGroup;
 import seedu.tp.group.GroupList;
 import seedu.tp.parser.Parser;
@@ -380,11 +382,13 @@ public class Ui {
 
     /**
      * Prints out all flashcards in the list ordered by start/birth date. Other cards come last.
+     * If a startDate and endDate is specified, prints all flashcards with startDate or birthDate in the
+     * range [startDate, endDate].
      * Used for TimelineCommand.
      *
      * @param flashcardList the list of flashcards to be printed out
      */
-    public void listAllFlashcardsOrdered(FlashcardList flashcardList) {
+    public void listAllFlashcardsOrdered(FlashcardList flashcardList, LocalDate startDate, LocalDate endDate) {
         assert flashcardList != null : "Invalid null flashcard list!";
 
         if (flashcardList.isEmpty()) {
@@ -394,9 +398,36 @@ public class Ui {
 
         List<Flashcard> flashcards = new ArrayList<>(flashcardList.getFlashcards());
         Collections.sort(flashcards);
-        System.out.println("Flashcards sorted by date:");
-        for (Flashcard f : flashcards) {
-            System.out.println(BULLET_POINT + f.getShortDescription());
+        if (startDate == null || endDate == null) {
+            System.out.println("Flashcards sorted by date:");
+            for (Flashcard f : flashcards) {
+                System.out.println(BULLET_POINT + f.getShortDescription());
+            }
+        } else {
+            System.out.println("Listing flashcards from " + startDate + " to " + endDate + "...");
+            boolean noFlashcards = true;
+            for (Flashcard f : flashcards) {
+                if (f instanceof EventFlashcard) {
+                    EventFlashcard eventFlashcard = (EventFlashcard) f;
+                    LocalDate eventStartDate = eventFlashcard.getStartDate();
+                    if (eventStartDate.compareTo(startDate) >= 0
+                        && eventStartDate.compareTo(endDate) <= 0) {
+                        System.out.println(BULLET_POINT + f.getShortDescription());
+                        noFlashcards = false;
+                    }
+                } else if (f instanceof PersonFlashcard) {
+                    PersonFlashcard personFlashcard = (PersonFlashcard) f;
+                    LocalDate personBirthDate = personFlashcard.getBirthDate();
+                    if (personBirthDate.compareTo(startDate) >= 0
+                        && personBirthDate.compareTo(endDate) <= 0) {
+                        System.out.println(BULLET_POINT + f.getShortDescription());
+                        noFlashcards = false;
+                    }
+                }
+            }
+            if (noFlashcards) {
+                System.out.println("No flashcards found in this period.");
+            }
         }
     }
 

--- a/src/main/java/seedu/tp/utils/Constants.java
+++ b/src/main/java/seedu/tp/utils/Constants.java
@@ -36,6 +36,7 @@ public class Constants {
     public static final String EMPTY_STRING = "";
     public static final String EMPTY_SPACE = " ";
     public static final String BULLET_POINT = "- ";
+    public static final String DIVIDER = " | ";
 
     public static final String REGEX_MATCH_ALL_CHARACTER = ".*";
 

--- a/src/test/java/seedu/tp/commands/DisplayStudyPlanCommandTest.java
+++ b/src/test/java/seedu/tp/commands/DisplayStudyPlanCommandTest.java
@@ -80,11 +80,11 @@ public class DisplayStudyPlanCommandTest {
     public void displayStudyPlanCommand_execute_success() {
         StringBuilder expectedEventOutput = new StringBuilder();
         expectedEventOutput.append("Date: 2020-01-18" + System.lineSeparator());
-        expectedEventOutput.append("1: Event 1 | Reviewed: N | Not indicated" + System.lineSeparator());
-        expectedEventOutput.append("3: Title 1 | Reviewed: N | Not indicated" + System.lineSeparator());
+        expectedEventOutput.append("1: Event 1 | Reviewed: X | Not indicated" + System.lineSeparator());
+        expectedEventOutput.append("3: Title 1 | Reviewed: X | Not indicated" + System.lineSeparator());
         expectedEventOutput.append("Date: 2020-02-27" + System.lineSeparator());
-        expectedEventOutput.append("1: Event 1 | Reviewed: N | Not indicated" + System.lineSeparator());
-        expectedEventOutput.append("2: Person 1 | Reviewed: N | Not indicated" + System.lineSeparator());
+        expectedEventOutput.append("1: Event 1 | Reviewed: X | Not indicated" + System.lineSeparator());
+        expectedEventOutput.append("2: Person 1 | Reviewed: X | Not indicated" + System.lineSeparator());
 
         DisplayStudyPlanCommand displayStudyPlanCommand = new DisplayStudyPlanCommand(new Ui(), studyPlanList,
             fullFlashcardList);

--- a/src/test/java/seedu/tp/commands/FindCommandTest.java
+++ b/src/test/java/seedu/tp/commands/FindCommandTest.java
@@ -64,9 +64,9 @@ public class FindCommandTest {
     public void findCommand_execute_listsFlashcardsSuccessfully() {
         StringBuilder expectedOutput = new StringBuilder();
         expectedOutput.append("Here's the list of flashcards you are looking for:" + System.lineSeparator());
-        expectedOutput.append("1: Event 1 | Reviewed: N | Not indicated | ID: 1" + System.lineSeparator());
-        expectedOutput.append("2: Person 1 | Reviewed: N | Not indicated | ID: 2" + System.lineSeparator());
-        expectedOutput.append("3: Title 1 | Reviewed: N | Not indicated | ID: 3" + System.lineSeparator());
+        expectedOutput.append("1: Event 1 | Reviewed: X | Not indicated | ID: 1" + System.lineSeparator());
+        expectedOutput.append("2: Person 1 | Reviewed: X | Not indicated | ID: 2" + System.lineSeparator());
+        expectedOutput.append("3: Title 1 | Reviewed: X | Not indicated | ID: 3" + System.lineSeparator());
 
         FindCommand findCommand = new FindCommand(fullFlashcardList, new Ui(), "1");
         findCommand.execute();

--- a/src/test/java/seedu/tp/commands/ListCommandTest.java
+++ b/src/test/java/seedu/tp/commands/ListCommandTest.java
@@ -64,9 +64,9 @@ public class ListCommandTest {
     public void listCommand_execute_listsFlashcardsSuccessfully() {
         StringBuilder expectedOutput = new StringBuilder();
         expectedOutput.append("Here's the list of flashcards you have:" + System.lineSeparator());
-        expectedOutput.append("1: Event 1 | Reviewed: N | Not indicated" + System.lineSeparator());
-        expectedOutput.append("2: Person 1 | Reviewed: N | Not indicated" + System.lineSeparator());
-        expectedOutput.append("3: Title 1 | Reviewed: N | Not indicated" + System.lineSeparator());
+        expectedOutput.append("1: Event 1 | Reviewed: X | Not indicated" + System.lineSeparator());
+        expectedOutput.append("2: Person 1 | Reviewed: X | Not indicated" + System.lineSeparator());
+        expectedOutput.append("3: Title 1 | Reviewed: X | Not indicated" + System.lineSeparator());
 
         ListCommand listCommand = new ListCommand(fullFlashcardList, new Ui());
         listCommand.execute();

--- a/src/test/java/seedu/tp/commands/ListReviewedCommandTest.java
+++ b/src/test/java/seedu/tp/commands/ListReviewedCommandTest.java
@@ -71,8 +71,8 @@ public class ListReviewedCommandTest {
     public void listReviewedCommand_execute_listsFlashcardsSuccessfully() {
         StringBuilder expectedOutput = new StringBuilder();
         expectedOutput.append("Here's the list of flashcards you are looking for:" + System.lineSeparator());
-        expectedOutput.append("1: Event 1 | Reviewed: Y | Not indicated | ID: 1" + System.lineSeparator());
-        expectedOutput.append("2: Title 1 | Reviewed: Y | Not indicated | ID: 3" + System.lineSeparator());
+        expectedOutput.append("1: Event 1 | Reviewed: / | Not indicated | ID: 1" + System.lineSeparator());
+        expectedOutput.append("2: Title 1 | Reviewed: / | Not indicated | ID: 3" + System.lineSeparator());
 
         ListReviewedCommand listReviewedCommand = new ListReviewedCommand(fullFlashcardList, new Ui());
         listReviewedCommand.execute();

--- a/src/test/java/seedu/tp/commands/TimelineCommandTest.java
+++ b/src/test/java/seedu/tp/commands/TimelineCommandTest.java
@@ -15,6 +15,7 @@ import java.io.PrintStream;
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.tp.utils.ExampleInputConstants.BULLET_POINT;
 import static seedu.tp.utils.ExampleInputConstants.DETAILS;
 import static seedu.tp.utils.ExampleInputConstants.SUMMARY;
 
@@ -45,11 +46,15 @@ public class TimelineCommandTest {
         flashcardList.addFlashcard(new PersonFlashcard("First", firstDate, firstDate, SUMMARY, DETAILS));
 
         StringBuilder expectedOutput = new StringBuilder();
-        expectedOutput.append("Here's a sorted list of the flashcards you have:" + System.lineSeparator());
-        expectedOutput.append(flashcardList.getFlashcardAtIdx(3) + System.lineSeparator());
-        expectedOutput.append(flashcardList.getFlashcardAtIdx(0) + System.lineSeparator());
-        expectedOutput.append(flashcardList.getFlashcardAtIdx(2) + System.lineSeparator());
-        expectedOutput.append(flashcardList.getFlashcardAtIdx(1) + System.lineSeparator());
+        expectedOutput.append("Flashcards sorted by date:" + System.lineSeparator());
+        expectedOutput.append(BULLET_POINT
+                + flashcardList.getFlashcardAtIdx(3).getShortDescription() + System.lineSeparator());
+        expectedOutput.append(BULLET_POINT
+                + flashcardList.getFlashcardAtIdx(0).getShortDescription() + System.lineSeparator());
+        expectedOutput.append(BULLET_POINT
+                + flashcardList.getFlashcardAtIdx(2).getShortDescription() + System.lineSeparator());
+        expectedOutput.append(BULLET_POINT
+                + flashcardList.getFlashcardAtIdx(1).getShortDescription() + System.lineSeparator());
 
         TimelineCommand timelineCommand = new TimelineCommand(flashcardList, new Ui());
         timelineCommand.execute();

--- a/src/test/java/seedu/tp/utils/ExampleInputConstants.java
+++ b/src/test/java/seedu/tp/utils/ExampleInputConstants.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public class ExampleInputConstants {
     public static final String NEWLINE = System.lineSeparator();
+    public static final String BULLET_POINT = "- ";
 
     public static final String FLASHCARD_NAME = "Example flashcard name";
     public static final String GROUP_NAME = "Example flashcard group name";

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -39,7 +39,7 @@ Details:
 * Functional end of Samurai Class
 
 Here's the list of flashcards you have:
-1: Meiji Restoration | Reviewed: N | Not indicated
+1: Meiji Restoration | Reviewed: X | Not indicated
 Please enter name:
 Please enter birth date:
 That date format couldn't be parsed! Please enter again.
@@ -58,8 +58,8 @@ Details:
 * Dumbledore became most famous for his defeat of Gellert Grindelwald, the discovery of the twelve uses of dragon's blood, and his work on alchemy with Nicolas Flamel
 
 Here's the list of flashcards you have:
-1: Meiji Restoration | Reviewed: N | Not indicated
-2: Albus Dumbledore | Reviewed: N | Not indicated
+1: Meiji Restoration | Reviewed: X | Not indicated
+2: Albus Dumbledore | Reviewed: X | Not indicated
 Please enter name:
 Please enter summary:
 Please enter detail (optional):
@@ -103,23 +103,23 @@ Flashcards sorted by date:
 - Albus Dumbledore | 1881-08-01 to 1997-06-30 | X | Not indicated
 - Resurrection Stone | X | Not indicated
 Here's the list of flashcards you have:
-1: Meiji Restoration | Reviewed: N | Not indicated
-2: Albus Dumbledore | Reviewed: N | Not indicated
-3: Resurrection Stone | Reviewed: N | Not indicated
-4: Quinn | Reviewed: N | Not indicated
+1: Meiji Restoration | Reviewed: X | Not indicated
+2: Albus Dumbledore | Reviewed: X | Not indicated
+3: Resurrection Stone | Reviewed: X | Not indicated
+4: Quinn | Reviewed: X | Not indicated
 Please enter date:
 Please enter indexes:
 Date: 2020-01-01
-1: Meiji Restoration | Reviewed: N | Not indicated
-3: Resurrection Stone | Reviewed: N | Not indicated
+1: Meiji Restoration | Reviewed: X | Not indicated
+3: Resurrection Stone | Reviewed: X | Not indicated
 Please enter date:
 That date format couldn't be parsed! Please enter again.
 Please enter indexes:
 Date: 2020-01-01
-1: Meiji Restoration | Reviewed: N | Not indicated
-3: Resurrection Stone | Reviewed: N | Not indicated
+1: Meiji Restoration | Reviewed: X | Not indicated
+3: Resurrection Stone | Reviewed: X | Not indicated
 Date: 2020-03-01
-2: Albus Dumbledore | Reviewed: N | Not indicated
+2: Albus Dumbledore | Reviewed: X | Not indicated
 There are no existing groups. Use "group" to create a new group.
 Please enter name:
 Please enter description:
@@ -157,54 +157,54 @@ Group description: This is a group for HP related stuff.
 There are 3 flashcards in this group.
 
 Here's the list of flashcards you have:
-1: Meiji Restoration | Reviewed: N | Not indicated
-2: Albus Dumbledore | Reviewed: N | Not indicated
-3: Resurrection Stone | Reviewed: N | Not indicated
-4: Quinn | Reviewed: N | Not indicated
+1: Meiji Restoration | Reviewed: X | Not indicated
+2: Albus Dumbledore | Reviewed: X | Not indicated
+3: Resurrection Stone | Reviewed: X | Not indicated
+4: Quinn | Reviewed: X | Not indicated
 Please use the correct input format. Use "help" to view all commands.
 Here's the list of flashcards you are looking for:
-1: Meiji Restoration | Reviewed: N | Not indicated | ID: 1
+1: Meiji Restoration | Reviewed: X | Not indicated | ID: 1
 Here's the list of flashcards you are looking for:
-1: Meiji Restoration | Reviewed: N | Not indicated | ID: 1
-2: Albus Dumbledore | Reviewed: N | Not indicated | ID: 2
-3: Resurrection Stone | Reviewed: N | Not indicated | ID: 3
+1: Meiji Restoration | Reviewed: X | Not indicated | ID: 1
+2: Albus Dumbledore | Reviewed: X | Not indicated | ID: 2
+3: Resurrection Stone | Reviewed: X | Not indicated | ID: 3
 Here's the list of flashcards you are looking for:
-1: Resurrection Stone | Reviewed: N | Not indicated | ID: 3
+1: Resurrection Stone | Reviewed: X | Not indicated | ID: 3
 The flashcard index you entered is invalid
 Here's the list of flashcards you have:
-1: Meiji Restoration | Reviewed: N | Not indicated
-2: Albus Dumbledore | Reviewed: N | Not indicated
-3: Resurrection Stone | Reviewed: N | Not indicated
-4: Quinn | Reviewed: N | Not indicated
+1: Meiji Restoration | Reviewed: X | Not indicated
+2: Albus Dumbledore | Reviewed: X | Not indicated
+3: Resurrection Stone | Reviewed: X | Not indicated
+4: Quinn | Reviewed: X | Not indicated
 The flashcard index you entered is invalid
 Here's the list of flashcards you have:
-1: Meiji Restoration | Reviewed: N | Not indicated
-2: Albus Dumbledore | Reviewed: N | Not indicated
-3: Resurrection Stone | Reviewed: N | Not indicated
-4: Quinn | Reviewed: N | Not indicated
+1: Meiji Restoration | Reviewed: X | Not indicated
+2: Albus Dumbledore | Reviewed: X | Not indicated
+3: Resurrection Stone | Reviewed: X | Not indicated
+4: Quinn | Reviewed: X | Not indicated
 The flashcard index you entered is invalid
 Here's the list of flashcards you have:
-1: Meiji Restoration | Reviewed: N | Not indicated
-2: Albus Dumbledore | Reviewed: N | Not indicated
-3: Resurrection Stone | Reviewed: N | Not indicated
-4: Quinn | Reviewed: N | Not indicated
+1: Meiji Restoration | Reviewed: X | Not indicated
+2: Albus Dumbledore | Reviewed: X | Not indicated
+3: Resurrection Stone | Reviewed: X | Not indicated
+4: Quinn | Reviewed: X | Not indicated
 Here's the list of flashcards you have:
-1: Albus Dumbledore | Reviewed: N | Not indicated
-2: Resurrection Stone | Reviewed: N | Not indicated
-3: Quinn | Reviewed: N | Not indicated
+1: Albus Dumbledore | Reviewed: X | Not indicated
+2: Resurrection Stone | Reviewed: X | Not indicated
+3: Quinn | Reviewed: X | Not indicated
 Here's the list of flashcards you have:
-1: Albus Dumbledore | Reviewed: N | Not indicated
-2: Quinn | Reviewed: N | Not indicated
+1: Albus Dumbledore | Reviewed: X | Not indicated
+2: Quinn | Reviewed: X | Not indicated
 You have no flashcard matching your query!
 You have marked the following flashcard as Reviewed:
 Albus Dumbledore
 Here's the list of flashcards you are looking for:
-1: Albus Dumbledore | Reviewed: Y | Not indicated | ID: 1
+1: Albus Dumbledore | Reviewed: / | Not indicated | ID: 1
 You have marked the following flashcard as Reviewed:
 Quinn
 Here's the list of flashcards you are looking for:
-1: Albus Dumbledore | Reviewed: Y | Not indicated | ID: 1
-2: Quinn | Reviewed: Y | Not indicated | ID: 2
+1: Albus Dumbledore | Reviewed: / | Not indicated | ID: 1
+2: Quinn | Reviewed: / | Not indicated | ID: 2
 These are the flashcard details:
 Person name: Albus Dumbledore
 Born: August 1, 1881
@@ -217,18 +217,18 @@ Details:
 Priority has been updated:
 Quinn | New priority: **
 Here's the list of flashcards you have:
-1: Albus Dumbledore | Reviewed: Y | Not indicated
-2: Quinn | Reviewed: Y | **
+1: Albus Dumbledore | Reviewed: / | Not indicated
+2: Quinn | Reviewed: / | **
 Here are all existing groups:
 1. Harry Potter Flashcards
 1 contains the following flashcards:
-- Albus Dumbledore | Reviewed: Y | Not indicated
-- Resurrection Stone | Reviewed: N | Not indicated
-- Meiji Restoration | Reviewed: N | Not indicated
+- Albus Dumbledore | Reviewed: / | Not indicated
+- Resurrection Stone | Reviewed: X | Not indicated
+- Meiji Restoration | Reviewed: X | Not indicated
 Harry Potter Flashcards contains the following flashcards:
-- Albus Dumbledore | Reviewed: Y | Not indicated
-- Resurrection Stone | Reviewed: N | Not indicated
-- Meiji Restoration | Reviewed: N | Not indicated
+- Albus Dumbledore | Reviewed: / | Not indicated
+- Resurrection Stone | Reviewed: X | Not indicated
+- Meiji Restoration | Reviewed: X | Not indicated
 Please use the correct input format. Use "help" to view all commands.
 Please enter a valid flashcard group name or index. Use "showgroups" to view all groups.
 Please enter a valid flashcard group name or index. Use "showgroups" to view all groups.

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -85,6 +85,15 @@ Listing flashcards from 1868-01-01 to 2020-01-01...
 - Albus Dumbledore | 1881-08-01 to 1997-06-30 | X | Not indicated
 Listing flashcards from 1850-01-01 to 1870-05-20...
 - Meiji Restoration | 1868-01-01 to 1868-01-01 | X | Not indicated
+Flashcards sorted by date:
+- Meiji Restoration | 1868-01-01 to 1868-01-01 | X | Not indicated
+- Albus Dumbledore | 1881-08-01 to 1997-06-30 | X | Not indicated
+- Resurrection Stone | X | Not indicated
+That date format couldn't be parsed!
+Flashcards sorted by date:
+- Meiji Restoration | 1868-01-01 to 1868-01-01 | X | Not indicated
+- Albus Dumbledore | 1881-08-01 to 1997-06-30 | X | Not indicated
+- Resurrection Stone | X | Not indicated
 Please enter name:
 Please enter birth date:
 Please enter death date:

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -74,6 +74,17 @@ Details:
 * It was bestowed upon Cadmus Peverell after he requested, as his bounty, something with the power to recall loved ones from Death
 * According to legend, whoever reunited it with the other two Hallows (the Elder Wand and the Cloak of Invisibility) would become the Master of Death
 
+Flashcards sorted by date:
+- Meiji Restoration | 1868-01-01 to 1868-01-01 | X | Not indicated
+- Albus Dumbledore | 1881-08-01 to 1997-06-30 | X | Not indicated
+- Resurrection Stone | X | Not indicated
+Listing flashcards from 2020-01-01 to 2020-01-01...
+No flashcards found in this period.
+Listing flashcards from 1868-01-01 to 2020-01-01...
+- Meiji Restoration | 1868-01-01 to 1868-01-01 | X | Not indicated
+- Albus Dumbledore | 1881-08-01 to 1997-06-30 | X | Not indicated
+Listing flashcards from 1850-01-01 to 1870-05-20...
+- Meiji Restoration | 1868-01-01 to 1868-01-01 | X | Not indicated
 Please enter name:
 Please enter birth date:
 Please enter death date:
@@ -86,36 +97,11 @@ Died: February 24, 1943
 Summary: 8)
 Details:
 
-Here's a sorted list of the flashcards you have:
-Event name: Meiji Restoration
-Event period: January 1, 1868-January 1, 1868
-Summary: Turning point in Japanese history
-Details:
-* End of Shogunate
-* Centralization of power
-* Functional end of Samurai Class
-
-Person name: Quinn
-Born: July 31, 1870
-Died: February 24, 1943
-Summary: 8)
-Details:
-
-Person name: Albus Dumbledore
-Born: August 1, 1881
-Died: June 30, 1997
-Summary: Albus Dumbledore was never proud or vain.
-Details:
-* He could find something to value in anyone, however apparently insignificant or wretched
-* Dumbledore became most famous for his defeat of Gellert Grindelwald, the discovery of the twelve uses of dragon's blood, and his work on alchemy with Nicolas Flamel
-
-Title: Resurrection Stone
-Summary: The Resurrection Stone is one of the fabled Deathly Hallows.
-Details:
-* In "The Tale of the Three Brothers", it was the second Hallow created, supposedly by Death himself
-* It was bestowed upon Cadmus Peverell after he requested, as his bounty, something with the power to recall loved ones from Death
-* According to legend, whoever reunited it with the other two Hallows (the Elder Wand and the Cloak of Invisibility) would become the Master of Death
-
+Flashcards sorted by date:
+- Meiji Restoration | 1868-01-01 to 1868-01-01 | X | Not indicated
+- Quinn | 1870-07-31 to 1943-02-24 | X | Not indicated
+- Albus Dumbledore | 1881-08-01 to 1997-06-30 | X | Not indicated
+- Resurrection Stone | X | Not indicated
 Here's the list of flashcards you have:
 1: Meiji Restoration | Reviewed: N | Not indicated
 2: Albus Dumbledore | Reviewed: N | Not indicated

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -33,7 +33,8 @@ timeline
 timeline 01-01-2020 01-01-2020
 timeline 01-01-1868 01-01-2020
 timeline 01-01-1850 20-05-1870
-timeline
+timeline asdfghjkl
+timeline 9999-99-99 9999-99-99
 person
 Quinn
 31/07/1870

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -33,6 +33,7 @@ timeline
 timeline 01-01-2020 01-01-2020
 timeline 01-01-1868 01-01-2020
 timeline 01-01-1850 20-05-1870
+timeline
 person
 Quinn
 31/07/1870

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -29,6 +29,10 @@ In "The Tale of the Three Brothers", it was the second Hallow created, supposedl
 It was bestowed upon Cadmus Peverell after he requested, as his bounty, something with the power to recall loved ones from Death
 According to legend, whoever reunited it with the other two Hallows (the Elder Wand and the Cloak of Invisibility) would become the Master of Death
 
+timeline
+timeline 01-01-2020 01-01-2020
+timeline 01-01-1868 01-01-2020
+timeline 01-01-1850 20-05-1870
 person
 Quinn
 31/07/1870


### PR DESCRIPTION
Allow users to type "timeline [startdate: DD-MM-YYYY] [enddate: DD-MM-YYYY]" to restrict timeline listings to this period (inclusive of start and end dates) only.
Also added a getShortDescription method to flashcards, and edited the default "timeline" command to list a short description instead of the full flashcard summary + details.